### PR TITLE
use the more idiomatic Query type instead QueryType

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,7 @@ repositories {
 You can now add a GraphQL schema in `src/main/resources/schema.graphqls` such as:
 
 ```
-schema {
-    query: QueryType
-}
-
-type QueryType {
+type Query {
     people: [Person]!
 }
 
@@ -104,7 +100,7 @@ public class PersonDataWiring implements RuntimeWiringCustomizer {
 
 	@Override
 	public void customize(RuntimeWiring.Builder builder) {
-		builder.type("QueryType", typeWiring -> typeWiring
+		builder.type("Query", typeWiring -> typeWiring
 				.dataFetcher("people", env -> this.personService.findAll()));
 	}
 }

--- a/samples/webmvc-http/src/main/java/io/spring/sample/graphql/project/ProjectDataWiring.java
+++ b/samples/webmvc-http/src/main/java/io/spring/sample/graphql/project/ProjectDataWiring.java
@@ -1,7 +1,6 @@
 package io.spring.sample.graphql.project;
 
 import graphql.schema.idl.RuntimeWiring;
-
 import org.springframework.graphql.boot.RuntimeWiringCustomizer;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +16,7 @@ public class ProjectDataWiring implements RuntimeWiringCustomizer {
 	@Override
 	public void customize(RuntimeWiring.Builder builder) {
 		builder
-				.type("QueryType", typeWiring ->
+				.type("Query", typeWiring ->
 						typeWiring.dataFetcher("project", env -> {
 							String slug = env.getArgument("slug");
 							return client.fetchProject(slug);

--- a/samples/webmvc-http/src/main/java/io/spring/sample/graphql/repository/ArtifactRepositoryDataWiring.java
+++ b/samples/webmvc-http/src/main/java/io/spring/sample/graphql/repository/ArtifactRepositoryDataWiring.java
@@ -1,7 +1,6 @@
 package io.spring.sample.graphql.repository;
 
 import graphql.schema.idl.RuntimeWiring;
-
 import org.springframework.graphql.boot.RuntimeWiringCustomizer;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +15,7 @@ public class ArtifactRepositoryDataWiring implements RuntimeWiringCustomizer {
 
 	@Override
 	public void customize(RuntimeWiring.Builder builder) {
-		builder.type("QueryType", typeWiring -> typeWiring
+		builder.type("Query", typeWiring -> typeWiring
 				.dataFetcher("artifactRepositories", env -> this.repositories.findAll())
 				.dataFetcher("artifactRepository", env -> this.repositories.findById(env.getArgument("id"))));
 	}

--- a/samples/webmvc-http/src/main/resources/schema.graphqls
+++ b/samples/webmvc-http/src/main/resources/schema.graphqls
@@ -1,8 +1,4 @@
-schema {
-    query: QueryType
-}
-
-type QueryType {
+type Query {
     artifactRepositories : [ArtifactRepository]
     artifactRepository(id : ID!) : ArtifactRepository
     project(slug: ID!): Project


### PR DESCRIPTION
`Query` doesn't require an extra `schema ...` inside the SDL and is more idiomatic in general.