### PR TITLE
only build GraphQL once

### DIFF
--- a/graphql-spring-boot-starter/src/main/java/org/springframework/graphql/boot/WebFluxGraphQLAutoConfiguration.java
+++ b/graphql-spring-boot-starter/src/main/java/org/springframework/graphql/boot/WebFluxGraphQLAutoConfiguration.java
@@ -58,13 +58,16 @@ public class WebFluxGraphQLAutoConfiguration {
 
 	private static final Log logger = LogFactory.getLog(WebFluxGraphQLAutoConfiguration.class);
 
+	@Bean
+	public GraphQL graphQL(GraphQL.Builder graphQLBuilder) {
+		return graphQLBuilder.build();
+	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public GraphQLHttpHandler graphQLHandler(GraphQL.Builder graphQLBuilder, ObjectProvider<WebInterceptor> interceptors) {
-		return new GraphQLHttpHandler(graphQLBuilder.build(), interceptors.orderedStream().collect(Collectors.toList()));
+	public GraphQLHttpHandler graphQLHandler(GraphQL graphQL, ObjectProvider<WebInterceptor> interceptors) {
+		return new GraphQLHttpHandler(graphQL, interceptors.orderedStream().collect(Collectors.toList()));
 	}
-
 	@Bean
 	public RouterFunction<ServerResponse> graphQLEndpoint(
 			GraphQLHttpHandler handler, GraphQLProperties properties, ResourceLoader resourceLoader) {
@@ -88,11 +91,11 @@ public class WebFluxGraphQLAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public GraphQLWebSocketHandler graphQLWebSocketHandler(
-				GraphQL.Builder graphQLBuilder, GraphQLProperties properties, ServerCodecConfigurer configurer,
+				GraphQL graphql, GraphQLProperties properties, ServerCodecConfigurer configurer,
 				ObjectProvider<WebInterceptor> interceptors) {
 
 			return new GraphQLWebSocketHandler(
-					graphQLBuilder.build(), interceptors.orderedStream().collect(Collectors.toList()),
+					graphql, interceptors.orderedStream().collect(Collectors.toList()),
 					configurer, properties.getWebsocket().getConnectionInitTimeout()
 			);
 		}

--- a/graphql-spring-boot-starter/src/main/java/org/springframework/graphql/boot/WebMvcGraphQLAutoConfiguration.java
+++ b/graphql-spring-boot-starter/src/main/java/org/springframework/graphql/boot/WebMvcGraphQLAutoConfiguration.java
@@ -65,12 +65,16 @@ public class WebMvcGraphQLAutoConfiguration {
 
 	private static final Log logger = LogFactory.getLog(WebMvcGraphQLAutoConfiguration.class);
 
+	@Bean
+	public GraphQL graphQL(GraphQL.Builder graphQLBuilder) {
+		return graphQLBuilder.build();
+	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public GraphQLHttpHandler graphQLHandler(GraphQL.Builder graphQLBuilder,
+	public GraphQLHttpHandler graphQLHandler(GraphQL graphQL,
 			ObjectProvider<WebInterceptor> interceptors) {
-		return new GraphQLHttpHandler(graphQLBuilder.build(), interceptors.orderedStream().collect(Collectors.toList()));
+		return new GraphQLHttpHandler(graphQL, interceptors.orderedStream().collect(Collectors.toList()));
 	}
 
 	@Bean
@@ -98,7 +102,7 @@ public class WebMvcGraphQLAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public GraphQLWebSocketHandler graphQLWebSocketHandler(
-				GraphQL.Builder graphQLBuilder, GraphQLProperties properties, HttpMessageConverters converters,
+				GraphQL graphQL, GraphQLProperties properties, HttpMessageConverters converters,
 				ObjectProvider<WebInterceptor> interceptors) {
 
 			HttpMessageConverter<?> converter = converters.getConverters().stream()
@@ -107,7 +111,7 @@ public class WebMvcGraphQLAutoConfiguration {
 					.orElseThrow(() -> new IllegalStateException("No JSON converter"));
 
 			return new GraphQLWebSocketHandler(
-					graphQLBuilder.build(), interceptors.orderedStream().collect(Collectors.toList()),
+					graphQL, interceptors.orderedStream().collect(Collectors.toList()),
 					converter, properties.getWebsocket().getConnectionInitTimeout()
 			);
 		}


### PR DESCRIPTION
Fix for #32 
Not sure this is the right way to ensure we only have one GraphQL instance. I am wondering how a user would configure it further: maybe we need to make the following `@ConditionalOnMissingBean` 

```java
	@Bean
	public GraphQL graphQL(GraphQL.Builder graphQLBuilder) {
		return graphQLBuilder.build();
	}
```
